### PR TITLE
Creating a custom SelectExpandClause breaks built in paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,68 @@ Desired Results:
 ```
 
 I can get these results using `[EnableQuery(PageSize = 2)]` but I need to be able to handle a custom skiptoken
+
+## Dynamic Expand Properties
+I need to be able to dynamically expand properties based on the Url. In one scenario, I need to expand `Actions` and in another I need to expose `Resources`. If I have these auto expanded with default paging, it works. When I remove the `[AutoExpand]` property, it does not add the nextlink.
+
+With `[AutoExpand]`
+```
+{
+    "@odata.context": "http://localhost:5197/odata/$metadata#identityGovernance/PermissionsAnalytics/Findings/WebApplication3.Models.EscalationFinding(Resources())/$entity",
+    "Id": "SomeId",
+    "Resources": [
+        {
+            "AuthorizationSystemId": "Id-1",
+            "AuthorizationSystemName": "Name-1",
+            "AuthorizationSystemType": "Aws"
+        },
+        {
+            "AuthorizationSystemId": "Id-2",
+            "AuthorizationSystemName": "Name-2",
+            "AuthorizationSystemType": "Aws"
+        }
+    ],
+    "Resources@odata.nextLink": "http://localhost:5197/odata/identityGovernance/PermissionsAnalytics/Findings/SomeId/WebApplication3.Models.EscalationFinding/Resources?$skiptoken=AuthorizationSystemId-%27Id-2%27"
+}
+```
+
+With Custom Expand properties
+```
+{
+    "@odata.context": "http://localhost:5197/odata/$metadata#identityGovernance/PermissionsAnalytics/Findings/WebApplication3.Models.EscalationFinding(Actions(),Resources())/$entity",
+    "Id": "SomeId",
+    "Actions": [
+        {
+            "Id": "123",
+            "AuthorizationSystemTypeDb": 0
+        }
+    ],
+    "Resources": [
+        {
+            "AuthorizationSystemId": "Id-1",
+            "AuthorizationSystemName": "Name-1",
+            "AuthorizationSystemType": "Aws"
+        },
+        {
+            "AuthorizationSystemId": "Id-2",
+            "AuthorizationSystemName": "Name-2",
+            "AuthorizationSystemType": "Aws"
+        },
+        {
+            "AuthorizationSystemId": "Id-3",
+            "AuthorizationSystemName": "Name-3",
+            "AuthorizationSystemType": "Aws"
+        },
+        {
+            "AuthorizationSystemId": "Id-4",
+            "AuthorizationSystemName": "Name-4",
+            "AuthorizationSystemType": "Aws"
+        },
+        {
+            "AuthorizationSystemId": "Id-5",
+            "AuthorizationSystemName": "Name-5",
+            "AuthorizationSystemType": "Aws"
+        }
+    ]
+}
+```

--- a/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
+++ b/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
@@ -27,12 +27,11 @@ namespace WebApplication3.Controllers
                 },
                 Resources = new List<AuthorizationSystem>()
                 {
-                    new CustomAuthorizationSystem()
+                    new AuthorizationSystem()
                     {
                         AuthorizationSystemId = "Id-1",
                         AuthorizationSystemName = "Name-1",
-                        AuthorizationSystemType = "Aws",
-                        Url = "http://any/evan2"
+                        AuthorizationSystemType = "Aws"
                     },
                     new AuthorizationSystem()
                     {
@@ -69,8 +68,8 @@ namespace WebApplication3.Controllers
             // Adding this change will allow me to expand these 2 navigation
             // properties BUT it won't allow the skip token/paging to work.
             // **********
-            _odata.SelectExpandClause = BuildCustomExpand(queryOptions,
-                $"Actions,Resources");
+            //_odata.SelectExpandClause = BuildCustomExpand(queryOptions,
+            //    $"Actions,Resources");
 
             // *******
             // To get a working copy:

--- a/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
+++ b/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
@@ -1,13 +1,16 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.UriParser;
+using System.Xml.Linq;
 using WebApplication3.Models;
 
 namespace WebApplication3.Controllers
 {
     public class TestingOdataController : ODataController
     {
-        [EnableQuery]
+        [EnableQuery(PageSize = 2)]
         [HttpGet("odata/IdentityGovernance/PermissionsAnalytics/Findings/{key}/WebApplication3.Models.EscalationFinding")]
         public IActionResult GetEscalation()
         {
@@ -24,11 +27,12 @@ namespace WebApplication3.Controllers
                 },
                 Resources = new List<AuthorizationSystem>()
                 {
-                    new AuthorizationSystem()
+                    new CustomAuthorizationSystem()
                     {
                         AuthorizationSystemId = "Id-1",
                         AuthorizationSystemName = "Name-1",
-                        AuthorizationSystemType = "Aws"
+                        AuthorizationSystemType = "Aws",
+                        Url = "http://any/evan2"
                     },
                     new AuthorizationSystem()
                     {
@@ -56,7 +60,51 @@ namespace WebApplication3.Controllers
                     },
                 }
             };
+
+            var _odata = Request.ODataFeature();
+            ODataQueryContext queryContext = new ODataQueryContext(_odata.Model, typeof(EscalationFinding), _odata.Path);
+            var queryOptions = new ODataQueryOptions<EscalationFinding>(queryContext, Request);
+
+            // **********
+            // Adding this change will allow me to expand these 2 navigation
+            // properties BUT it won't allow the skip token/paging to work.
+            // **********
+            _odata.SelectExpandClause = BuildCustomExpand(queryOptions,
+                $"Actions,Resources");
+
+            // *******
+            // To get a working copy:
+            //  Commented out the above line
+            //  Add back [AutoExpand] to the 2 navigation properties
+            // *******
+
+
             return Ok(ret);
+        }
+
+        private SelectExpandClause BuildCustomExpand(ODataQueryOptions queryOptions, string expandProperty)
+        {
+            // NOTE: For some reason, I needed to `.ToLower()` on the expandProperty that had
+            // a capital letter (Accounts and Resources) to get it to work.
+            // From what I can tell, if the targetEdmType is null it doesn't check.
+            // Changing
+            //  TargetEdmType: queryOptions.Context.NavigationSource.EntityType() <-- this is null
+            //      to
+            //  TargetEdmType: queryOptions.Context.ElementType
+            // caused the MappingServiceTests to fail.
+
+            var expandOptions = new SelectExpandQueryOption(null, expandProperty, queryOptions.Context,
+                new ODataQueryOptionParser(
+                    model: queryOptions.Context.Model,
+                    targetEdmType: queryOptions.Context.ElementType,// queryOptions.Context.NavigationSource.EntityType(),
+                    targetNavigationSource: queryOptions.Context.NavigationSource,
+                    queryOptions: new Dictionary<string, string> { { "$expand", expandProperty } },
+                    container: queryOptions.Context.RequestContainer
+                    )
+                );
+
+
+            return expandOptions.SelectExpandClause;
         }
     }
 }

--- a/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
+++ b/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
@@ -2,17 +2,19 @@
 using Microsoft.AspNetCore.OData.Extensions;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 using System.Xml.Linq;
+using WebApplication3.Extensions;
 using WebApplication3.Models;
 
 namespace WebApplication3.Controllers
 {
     public class TestingOdataController : ODataController
     {
-        [EnableQuery(PageSize = 2)]
+        [EvanEnableQuery(PageSize = 2)]
         [HttpGet("odata/IdentityGovernance/PermissionsAnalytics/Findings/{key}/WebApplication3.Models.EscalationFinding")]
-        public IActionResult GetEscalation()
+        public IActionResult GetEscalation(ODataQueryOptions<EscalationFinding> opts)
         {
             EscalationFinding ret = new EscalationFinding()
             {
@@ -68,8 +70,7 @@ namespace WebApplication3.Controllers
             // Adding this change will allow me to expand these 2 navigation
             // properties BUT it won't allow the skip token/paging to work.
             // **********
-            _odata.SelectExpandClause = BuildCustomExpand(queryOptions,
-                $"Actions,Resources");
+            _odata.SelectExpandClause = BuildCustomExpand(opts,$"actions,resources");
 
             // *******
             // To get a working copy:

--- a/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
+++ b/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs
@@ -68,8 +68,8 @@ namespace WebApplication3.Controllers
             // Adding this change will allow me to expand these 2 navigation
             // properties BUT it won't allow the skip token/paging to work.
             // **********
-            //_odata.SelectExpandClause = BuildCustomExpand(queryOptions,
-            //    $"Actions,Resources");
+            _odata.SelectExpandClause = BuildCustomExpand(queryOptions,
+                $"Actions,Resources");
 
             // *******
             // To get a working copy:

--- a/WebApplication3/WebApplication3/Extensions/EvanEnableQueryAttribute.cs
+++ b/WebApplication3/WebApplication3/Extensions/EvanEnableQueryAttribute.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.OData.Extensions;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.OData.UriParser;
+using System.Text;
+using System.Xml.Linq;
+using WebApplication3.Models;
+
+namespace WebApplication3.Extensions
+{
+    public class EvanEnableQueryAttribute : EnableQueryAttribute
+    {
+        public override object ApplyQuery(object entity, ODataQueryOptions queryOptions)
+        {
+            // These don't match
+            var a = queryOptions.SelectExpand;
+            var b = queryOptions.Request.ODataFeature().SelectExpandClause;
+            var c = queryOptions.Request.ODataFeature();
+            
+            if (a == null && b != null)
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("?$expand=");
+                foreach (var itm in b.SelectedItems)
+                {
+                    if (itm is ExpandedNavigationSelectItem exp)
+                    {
+                        var name = exp.NavigationSource.Name;
+                        sb.Append(name).Append(",");
+                    }
+                }
+                var str = sb.ToString().TrimEnd(',');
+            
+            
+                QueryString qs = new QueryString(str);
+                queryOptions.Request.QueryString = qs;
+            
+                var _odata = queryOptions.Request.ODataFeature();
+                ODataQueryContext queryContext = new ODataQueryContext(_odata.Model, entity.GetType()/*typeof(EscalationFinding)*/, _odata.Path);
+                var _options = new ODataQueryOptions/*<EscalationFinding>*/(queryContext, queryOptions.Request);
+            
+                return base.ApplyQuery(entity, _options);
+            }
+
+            var ret = base.ApplyQuery(entity, queryOptions);
+            return ret;
+        }
+    }
+}

--- a/WebApplication3/WebApplication3/Extensions/EvanSkipTokenHandler.cs
+++ b/WebApplication3/WebApplication3/Extensions/EvanSkipTokenHandler.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using Microsoft.AspNetCore.OData.Formatter.Value;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.OData.Edm;
+
+namespace WebApplication3.Extensions
+{
+    public class EvanSkipTokenHandler : DefaultSkipTokenHandler
+    {
+
+        public override Uri GenerateNextPageLink(Uri baseUri, int pageSize, object instance, ODataSerializerContext context)
+        {
+            //IEdmModel model = context.Model;
+            //IEdmStructuredObject obj = instance as IEdmStructuredObject;
+            //
+            //var val = instance.GetType().GetProperty("Resources").GetValue("externalId");
+            //
+            //
+            //return new Uri("https://evan.com");
+            return base.GenerateNextPageLink(baseUri, pageSize, instance, context);
+        }
+    }
+}

--- a/WebApplication3/WebApplication3/Extensions/IPageSizeProvider.cs
+++ b/WebApplication3/WebApplication3/Extensions/IPageSizeProvider.cs
@@ -1,0 +1,17 @@
+﻿namespace WebApplication3.Extensions
+{
+    public interface IPageSizeProvider
+    {
+        int PageSize { get; }
+    }
+
+    public class PageSizeProvider : IPageSizeProvider
+    {
+        public PageSizeProvider(int pageSize)
+        {
+            PageSize = pageSize;
+        }
+
+        public int PageSize { get; }
+    }
+}

--- a/WebApplication3/WebApplication3/Extensions/MyResourceSetSerializer.cs
+++ b/WebApplication3/WebApplication3/Extensions/MyResourceSetSerializer.cs
@@ -3,6 +3,9 @@ using Microsoft.OData.Edm;
 using Microsoft.OData;
 using Microsoft.AspNetCore.OData.Query.Container;
 using System.Collections;
+using System.Linq;
+using WebApplication3.Models;
+using Microsoft.AspNetCore.OData.Formatter;
 
 namespace WebApplication3.Extensions
 {
@@ -12,33 +15,33 @@ namespace WebApplication3.Extensions
         {
         }
 
-        public override async Task WriteObjectInlineAsync(object graph, IEdmTypeReference expectedType, ODataWriter writer,
-            ODataSerializerContext writeContext)
-        {
-            int pageSize = writeContext.Request.HttpContext.RequestServices.GetRequiredService<IPageSizeProvider>().PageSize;
-
-            if (writeContext.ExpandedResource != null && writeContext.EdmProperty.Name == "Resources" &&
-                graph is IEnumerable enumerable)
-            {
-                IList<object> objects = new List<object>();
-                int count = 0;
-                foreach (var item in enumerable)
-                {
-                    objects.Add(item);
-                    count++;
-                    if (count >= pageSize)
-                    {
-                        break;
-                    }
-                }
-
-                await base.WriteObjectInlineAsync(objects, expectedType, writer, writeContext).ConfigureAwait(false);
-            }
-            else
-            {
-                await base.WriteObjectInlineAsync(graph, expectedType, writer, writeContext).ConfigureAwait(false);
-            }
-        }
+        //public override async Task WriteObjectInlineAsync(object graph, IEdmTypeReference expectedType, ODataWriter writer,
+        //    ODataSerializerContext writeContext)
+        //{
+        //    int pageSize = writeContext.Request.HttpContext.RequestServices.GetRequiredService<IPageSizeProvider>().PageSize;
+        //
+        //    if (writeContext.ExpandedResource != null && writeContext.EdmProperty.Name == "Resources" &&
+        //        graph is IEnumerable enumerable)
+        //    {
+        //        IList<object> objects = new List<object>();
+        //        int count = 0;
+        //        foreach (var item in enumerable)
+        //        {
+        //            objects.Add(item);
+        //            count++;
+        //            if (count >= pageSize)
+        //            {
+        //                break;
+        //            }
+        //        }
+        //
+        //        await base.WriteObjectInlineAsync(objects, expectedType, writer, writeContext).ConfigureAwait(false);
+        //    }
+        //    else
+        //    {
+        //        await base.WriteObjectInlineAsync(graph, expectedType, writer, writeContext).ConfigureAwait(false);
+        //    }
+        //}
 
         public override ODataResourceSet CreateResourceSet(IEnumerable resourceSetInstance, IEdmCollectionTypeReference resourceSetType,
             ODataSerializerContext writeContext)
@@ -47,10 +50,33 @@ namespace WebApplication3.Extensions
 
             if (writeContext.ExpandedResource != null && writeContext.EdmProperty.Name == "Resources")
             {
-                set.NextPageLink = new Uri("http://any");
+                
+
+                //var itm = resourceSetInstance.GetEnumerator().Current;
+                
+
+                //set.NextPageLink = new Uri("http://any");
             }
 
             return set;
+        }
+    }
+
+    public class EvanSerial : ODataResourceSerializer
+    {
+        public EvanSerial(IODataSerializerProvider serializerProvider) : base(serializerProvider)
+        {
+        }
+
+        public override ODataResource CreateResource(SelectExpandNode selectExpandNode, ResourceContext resourceContext)
+        {
+            var resource = base.CreateResource(selectExpandNode, resourceContext);
+            IEdmStructuredType stype = resourceContext.StructuredType as IEdmStructuredType;
+            if (stype != null && stype.TypeKind == EdmTypeKind.Complex)
+            {
+                resource.TypeAnnotation = new ODataTypeAnnotation(resourceContext.StructuredType.FullTypeName());
+            }
+            return resource;
         }
     }
 }

--- a/WebApplication3/WebApplication3/Extensions/MyResourceSetSerializer.cs
+++ b/WebApplication3/WebApplication3/Extensions/MyResourceSetSerializer.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using Microsoft.OData.Edm;
+using Microsoft.OData;
+using Microsoft.AspNetCore.OData.Query.Container;
+using System.Collections;
+
+namespace WebApplication3.Extensions
+{
+    public class MyResourceSetSerializer : ODataResourceSetSerializer
+    {
+        public MyResourceSetSerializer(IODataSerializerProvider serializerProvider) : base(serializerProvider)
+        {
+        }
+
+        public override async Task WriteObjectInlineAsync(object graph, IEdmTypeReference expectedType, ODataWriter writer,
+            ODataSerializerContext writeContext)
+        {
+            int pageSize = writeContext.Request.HttpContext.RequestServices.GetRequiredService<IPageSizeProvider>().PageSize;
+
+            if (writeContext.ExpandedResource != null && writeContext.EdmProperty.Name == "Resources" &&
+                graph is IEnumerable enumerable)
+            {
+                IList<object> objects = new List<object>();
+                int count = 0;
+                foreach (var item in enumerable)
+                {
+                    objects.Add(item);
+                    count++;
+                    if (count >= pageSize)
+                    {
+                        break;
+                    }
+                }
+
+                await base.WriteObjectInlineAsync(objects, expectedType, writer, writeContext).ConfigureAwait(false);
+            }
+            else
+            {
+                await base.WriteObjectInlineAsync(graph, expectedType, writer, writeContext).ConfigureAwait(false);
+            }
+        }
+
+        public override ODataResourceSet CreateResourceSet(IEnumerable resourceSetInstance, IEdmCollectionTypeReference resourceSetType,
+            ODataSerializerContext writeContext)
+        {
+            ODataResourceSet set = base.CreateResourceSet(resourceSetInstance, resourceSetType, writeContext);
+
+            if (writeContext.ExpandedResource != null && writeContext.EdmProperty.Name == "Resources")
+            {
+                set.NextPageLink = new Uri("http://any");
+            }
+
+            return set;
+        }
+    }
+}

--- a/WebApplication3/WebApplication3/Models/EscalationFinding.cs
+++ b/WebApplication3/WebApplication3/Models/EscalationFinding.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.OData.ModelBuilder;
+using System.Runtime.Serialization;
 
 namespace WebApplication3.Models
 {
@@ -6,10 +7,22 @@ namespace WebApplication3.Models
     {
         public string Id { get; set; }
 
-        [AutoExpand]
+        //[AutoExpand]
         public List<AuthorizationSystemTypeAction> Actions { get; set; }
 
-        [AutoExpand]
+        //[AutoExpand]
         public List<AuthorizationSystem> Resources { get; set; }
+    }
+
+
+    public class  CustomList : List<AuthorizationSystem>
+    {
+        public string CustomUrl { get; set; }
+    }
+
+    public class CustomAuthorizationSystem : AuthorizationSystem
+    {
+        [IgnoreDataMember]
+        public string Url { get; set; }
     }
 }

--- a/WebApplication3/WebApplication3/Models/EscalationFinding.cs
+++ b/WebApplication3/WebApplication3/Models/EscalationFinding.cs
@@ -7,10 +7,10 @@ namespace WebApplication3.Models
     {
         public string Id { get; set; }
 
-        [AutoExpand]
+        //[AutoExpand]
         public List<AuthorizationSystemTypeAction> Actions { get; set; }
 
-        [AutoExpand]
+        //[AutoExpand]
         public List<AuthorizationSystem> Resources { get; set; }
     }
 

--- a/WebApplication3/WebApplication3/Models/EscalationFinding.cs
+++ b/WebApplication3/WebApplication3/Models/EscalationFinding.cs
@@ -7,10 +7,10 @@ namespace WebApplication3.Models
     {
         public string Id { get; set; }
 
-        //[AutoExpand]
+        [AutoExpand]
         public List<AuthorizationSystemTypeAction> Actions { get; set; }
 
-        //[AutoExpand]
+        [AutoExpand]
         public List<AuthorizationSystem> Resources { get; set; }
     }
 

--- a/WebApplication3/WebApplication3/Program.cs
+++ b/WebApplication3/WebApplication3/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.OData;
 using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using Microsoft.AspNetCore.OData.Query;
 using WebApplication3.Extensions;
 using WebApplication3.Models;
 
@@ -11,7 +12,11 @@ var model = EdmModelBuilder.GetEdmModel();
 
 builder.Services.AddControllers().
     AddOData(opt => opt.AddRouteComponents("odata", model,
-    services => services.AddSingleton<ODataResourceSetSerializer, MyResourceSetSerializer>()).EnableQueryFeatures());
+    services => {
+        //services.AddSingleton<ODataResourceSetSerializer, MyResourceSetSerializer>();
+        //services.AddSingleton<ODataResourceSerializer, EvanSerial>();
+        //services.AddSingleton<SkipTokenHandler, EvanSkipTokenHandler>();
+    }).EnableQueryFeatures());
 
 builder.Services.AddSingleton<IPageSizeProvider>(sp => new PageSizeProvider(3));
 

--- a/WebApplication3/WebApplication3/Program.cs
+++ b/WebApplication3/WebApplication3/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.OData;
 using Microsoft.AspNetCore.OData.Edm;
+using Microsoft.AspNetCore.OData.Formatter.Serialization;
+using WebApplication3.Extensions;
 using WebApplication3.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,7 +10,10 @@ var builder = WebApplication.CreateBuilder(args);
 var model = EdmModelBuilder.GetEdmModel();
 
 builder.Services.AddControllers().
-    AddOData(opt => opt.AddRouteComponents("odata", model).EnableQueryFeatures());
+    AddOData(opt => opt.AddRouteComponents("odata", model,
+    services => services.AddSingleton<ODataResourceSetSerializer, MyResourceSetSerializer>()).EnableQueryFeatures());
+
+builder.Services.AddSingleton<IPageSizeProvider>(sp => new PageSizeProvider(3));
 
 var app = builder.Build();
 

--- a/WebApplication3/WebApplication3/Properties/launchSettings.json
+++ b/WebApplication3/WebApplication3/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "$odata",
+      "launchUrl": "odata/IdentityGovernance/PermissionsAnalytics/Findings/%7Bkey%7D/WebApplication3.Models.EscalationFinding",// "$odata",
       "applicationUrl": "http://localhost:5197",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
**Problem Statement**: I want to determine at run time which navigation properties are expanded.
**Potential Solution**: I created a custom method that will build the new SelectExpandClause.
**Issue**: When I do this, I am not able to handle the built in paging.

What is should look like:
<img width="445" alt="image" src="https://github.com/EvanHennisAtMicrosoft/ODataTests/assets/112125235/5d21cba5-0843-4163-8b35-90d5eec66a25">

What is does look like:
<img width="400" alt="image" src="https://github.com/EvanHennisAtMicrosoft/ODataTests/assets/112125235/7ba5cb79-a83c-4497-9253-d86ccb2481c4">

[Code Block](https://github.com/EvanHennisAtMicrosoft/ODataTests/blob/648fe8b9dbf3ecfab854ae043e87e746a6f87830/WebApplication3/WebApplication3/Controllers/TestingOdataController.cs#L72)